### PR TITLE
Add clients-by-role functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ go build -v .
 
 #### Run hive in dev mode
 ```bash
-./hive --dev
+./hive --dev --client go-ethereum,lighthouse-bn,lighthouse-vc
 ```
 
 #### Run tests

--- a/src/hive/client.py
+++ b/src/hive/client.py
@@ -1,5 +1,6 @@
 import json
 from dataclasses import dataclass
+from enum import Enum
 from http import client
 from io import BufferedReader, BytesIO
 from ipaddress import IPv4Address, IPv6Address, ip_address
@@ -8,11 +9,24 @@ from typing import Any, Dict, List, Mapping, Tuple
 import requests
 
 
+class ClientRole(str, Enum):
+    ExecutionClient = "eth1"
+    BeaconClient = "beacon"
+    ValidatorClient = "validator"
+
+
 @dataclass(kw_only=True)
 class ClientType:
     name: str
     version: str
     meta: Dict[str, Any]
+
+    def roles(self) -> List[str]:
+        roles = []
+        if "roles" in self.meta:
+            roles = self.meta["roles"]
+            assert isinstance(roles, list)
+        return roles
 
 
 @dataclass(kw_only=True)

--- a/src/hive/simulation.py
+++ b/src/hive/simulation.py
@@ -3,7 +3,7 @@ from typing import List
 
 import requests
 
-from .client import ClientType
+from .client import ClientRole, ClientType
 from .testing import HiveTestSuite
 
 # from enode import enode
@@ -42,10 +42,13 @@ class Simulation:
         url = f"{self.url}/testsuite"
         return HiveTestSuite.start(url=url, name=name, description=description)
 
-    def client_types(self) -> List[ClientType]:
+    def client_types(self, *, role: ClientRole | None = None) -> List[ClientType]:
         url = f"{self.url}/clients"
         response = requests.get(url)
         response.raise_for_status()
         client_list = response.json()
         assert isinstance(client_list, list)
-        return [ClientType(**x) for x in client_list]
+        clients = [ClientType(**x) for x in client_list]
+        if role:
+            return [c for c in clients if role in c.roles()]
+        return clients

--- a/src/hive/tests/test_sanity.py
+++ b/src/hive/tests/test_sanity.py
@@ -1,14 +1,22 @@
 import os
 from re import match
 
+import pytest
+
+from hive.client import ClientRole
 from hive.parameters import Parameter
 from hive.simulation import Simulation
 from hive.testing import HiveTestResult
 
 
-def test_sanity():
-    sim = Simulation(url="http://127.0.0.1:3000")
+@pytest.fixture
+def sim():
+    # TODO: Start hive in dev mode here
+    yield Simulation(url="http://127.0.0.1:3000")
+    # TODO: Clean it up here
 
+
+def test_sanity(sim: Simulation):
     clients = sim.client_types()
 
     assert clients
@@ -27,6 +35,7 @@ def test_sanity():
             "genesis.json": os.path.join("src", "hive", "tests", "genesis.json"),
         },
     )
+    assert c1 is not None
 
     # Check enode
     enode = c1.enode()
@@ -53,3 +62,20 @@ def test_sanity():
 
     t.end(result=HiveTestResult(test_pass=True, details="some details"))
     suite.end()
+
+
+def test_clients_by_role(sim: Simulation):
+    execution_clients = sim.client_types(role=ClientRole.ExecutionClient)
+    assert len(execution_clients) == 1, "Expected 1 execution client, got {}".format(
+        len(execution_clients)
+    )
+
+    beacon_clients = sim.client_types(role=ClientRole.BeaconClient)
+    assert len(beacon_clients) == 1, "Expected 1 execution client, got {}".format(
+        len(beacon_clients)
+    )
+
+    validator_clients = sim.client_types(role=ClientRole.ValidatorClient)
+    assert len(validator_clients) == 1, "Expected 1 execution client, got {}".format(
+        len(validator_clients)
+    )


### PR DESCRIPTION
Adds `role` parameter to `client_types` function of the simulation class to be able to filter clients by their role.