### PR TITLE
chore: relax dependencies for execution-spec-tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ install_requires =
     mypy==1.4.1
     mypy-extensions==1.0.0
     packaging==23.1
-    pluggy==1.2.0
+    pluggy>=1.3.0,<2.0.0
     requests==2.31.0
     tomli==2.0.1
     types-requests==2.31.0.2


### PR DESCRIPTION
Small change to install deps that allows `hive.py` to be installed alongside `execution-spec-tests`.