### PR TITLE
fix:(client): fix the `files` definition in `post_with_files()`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ install_requires =
     mypy==1.4.1
     mypy-extensions==1.0.0
     packaging==23.1
-    pluggy==1.2.0
+    pluggy>=1.3.0,<2.0.0
     requests==2.31.0
     tomli==2.0.1
     types-requests==2.31.0.2

--- a/src/hive/client.py
+++ b/src/hive/client.py
@@ -46,7 +46,7 @@ class ClientConfig:
                 if isinstance(open_fn_or_name, str):
                     open_fn_or_name = open(open_fn_or_name, "rb")
                 assert isinstance(open_fn_or_name, BufferedReader)
-                files["file"] = (filename, open_fn_or_name)
+                files[filename] = open_fn_or_name
 
         # Send the request.
         config_dict = {


### PR DESCRIPTION
Requires #4.

Small fix to the definition of `files` in `post_with_files()` to specify which local files should be copied to the client's container.