### PR TITLE
chore: move mypy deps to lint extras section

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,8 +25,6 @@ install_requires =
     exceptiongroup==1.1.2
     idna==3.4
     iniconfig==2.0.0
-    mypy==1.4.1
-    mypy-extensions==1.0.0
     packaging==23.1
     pluggy>=1.3.0,<2.0.0
     requests==2.31.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,3 +45,6 @@ hive =
 test =
     pytest==7.4.0
     pytest-cov>=4.1.0,<5
+lint =
+    mypy==1.4.1
+    mypy-extensions==1.0.0


### PR DESCRIPTION
This PR moves the mypy package dependencies to a new lint "extras" section. Using mypy as an install dependency forces downstream packages to use this version.