### PR TITLE
feat: support test suite client

### DIFF
--- a/src/hive/testing.py
+++ b/src/hive/testing.py
@@ -24,6 +24,10 @@ class HiveTestSuite:
     def end(self):
         response = requests.delete(self.url)
         response.raise_for_status()
+    
+    def start_client(self, **kwargs) -> Client | None:
+        kwargs["url"] = f"{self.url}/node"
+        return Client.start(**kwargs)
 
     def start_test(self, name: str, description: str) -> "HiveTest":
         url = f"{self.url}/test"


### PR DESCRIPTION
Adds `start_client` to `HiveTestSuite`.

Requires https://github.com/ethereum/hive/pull/1285