### PR TITLE
chore(ci): add a smoke test that verifies package installation

### DIFF
--- a/tests/smoke_test.py
+++ b/tests/smoke_test.py
@@ -1,0 +1,9 @@
+"""Smoke test: verify the package is importable and exports its public API."""
+
+import hive
+
+assert hive.__version__
+for name in ("Client", "ClientRole", "ClientType", "Network", "Simulation", "HiveTestSuite"):
+    assert hasattr(hive, name), f"missing export: {name}"
+
+print(f"hive {hive.__version__} OK")


### PR DESCRIPTION
This test is intentionally not in `src/hive/tests` as it's not a unit test, rather it verifies that the package can be imported following installation.